### PR TITLE
feat: add pagination to public methods

### DIFF
--- a/src/entities/channel.ts
+++ b/src/entities/channel.ts
@@ -117,7 +117,11 @@ export class Channel {
   /**
    * The channel's comments. Only defined when [[Channel.fetchComments]] is called.
    */
-  public comments: YTComment[]
+  public comments: {
+    results: YTComment[]
+    prevPageToken: string
+    nextPageToken: string
+  }
 
   /**
    * The URLs of all of this channel's featured channels. This property is broken for some channels.
@@ -128,17 +132,29 @@ export class Channel {
   /**
    * The channel's playlists. Only defined when [[Channel.fetchPlaylists]] is called.
    */
-  public playlists: Playlist[]
+  public playlists: {
+    results: Playlist[]
+    prevPageToken: string
+    nextPageToken: string
+  }
 
   /**
    * The channel's subscriptions. Only defined when [[Channel.fetchSubscriptions]] is called.
    */
-  public subscriptions: Subscription[]
+  public subscriptions: {
+    results: Subscription[]
+    prevPageToken: string
+    nextPageToken: string
+  }
 
   /**
    * The channel's sections. Only defined when [[Channel.fetchSections]] is called.
    */
-  public sections: ChannelSection[]
+  public sections: {
+    results: ChannelSection[]
+    prevPageToken: string
+    nextPageToken: string
+  }
 
   /**
    * Only set if the channel is a search result.
@@ -275,9 +291,9 @@ export class Channel {
     const comment = await this.youtube.oauth.postComment(text, this.id)
 
     if (this.comments !== undefined) {
-      this.comments.push(comment)
+      this.comments.results.push(comment)
     } else {
-      this.comments = [ comment ]
+      this.comments = { results: [ comment ], prevPageToken: undefined, nextPageToken: undefined }
     }
 
     return comment
@@ -310,8 +326,8 @@ export class Channel {
    * Fetches the channel's discussion tab comments and assigns them to Channel.comments.
    * @param maxResults The maximum amount of comments to fetch
    */
-  public async fetchComments (maxResults: number = 10, parts?: CommentThreadParts) {
-    this.comments = await this.youtube.getChannelComments(this.id, maxResults, parts)
+  public async fetchComments (maxResults: number = 10, parts?: CommentThreadParts, pages: number = 1, pageToken?: string) {
+    this.comments = await this.youtube.getChannelComments(this.id, maxResults, parts, pages, pageToken)
     return this.comments
   }
 
@@ -319,8 +335,8 @@ export class Channel {
    * Fetches the channel's playlists and assigns them to Channel.playlists.
    * @param maxResults The maximum amount of playlists to fetch
    */
-  public async fetchPlaylists (maxResults: number = 10, parts?: PlaylistParts) {
-    this.playlists = await this.youtube.getChannelPlaylists(this.id, maxResults, parts)
+  public async fetchPlaylists (maxResults: number = 10, parts?: PlaylistParts, pages: number = 1, pageToken?: string) {
+    this.playlists = await this.youtube.getChannelPlaylists(this.id, maxResults, parts, pages, pageToken)
     return this.playlists
   }
 
@@ -329,16 +345,16 @@ export class Channel {
    * @param maxResults The maximum amount of subscriptions to fetch
    */
   /* istanbul ignore next */
-  public async fetchSubscriptions (maxResults: number = 10, parts?: SubscriptionParts) {
-    this.subscriptions = await this.youtube.getChannelSubscriptions(this.id, maxResults, parts)
+  public async fetchSubscriptions (maxResults: number = 10, parts?: SubscriptionParts, pages: number = 1, pageToken?: string) {
+    this.subscriptions = await this.youtube.getChannelSubscriptions(this.id, maxResults, parts, pages, pageToken)
     return this.subscriptions
   }
 
   /**
    * Fetches the channel's sections and assigns them to [[Channel.sections]].
    */
-  public async fetchSections (parts?: ChannelSectionParts) {
-    this.sections = await this.youtube.getChannelSections(this.id, parts)
+  public async fetchSections (parts?: ChannelSectionParts, pages: number = 1, pageToken?: string) {
+    this.sections = await this.youtube.getChannelSections(this.id, parts, pages, pageToken)
     return this.sections
   }
 

--- a/src/entities/comment.ts
+++ b/src/entities/comment.ts
@@ -121,7 +121,11 @@ export class YTComment {
    * then this will be partially filled. You'll need to use [[Comment.fetchReplies]]
    * to get all of the replies, though.
    */
-  public replies: YTComment[]
+  public replies: {
+    results: YTComment[]
+    prevPageToken: string
+    nextPageToken: string
+  }
 
   constructor (youtube: YouTube, data: any, type: 'video' | 'channel') {
     this.youtube = youtube
@@ -167,16 +171,14 @@ export class YTComment {
     if (this.parentId) {
       this.url = 'https://youtube.com/' + (type === 'channel' ? `channel/${this.parentId}/discussion?lc=${this.id}` : `watch?v=${this.parentId}&lc=${this.id}`)
     }
-
-    this.replies = []
   }
 
   /**
    * Fetches replies to the comment.
    * @param maxResults The maximum amount of replies to fetch. Fetches all comments if <=0.
    */
-  public async fetchReplies (maxResults: number = 10, parts?: CommentParts) {
-    this.replies = await this.youtube.getCommentReplies(this.id, maxResults, parts)
+  public async fetchReplies (maxResults: number = 10, parts?: CommentParts, pageToken?: string) {
+    this.replies = await this.youtube.getCommentReplies(this.id, maxResults, parts, pageToken)
     return this.replies
   }
 

--- a/src/entities/playlist.ts
+++ b/src/entities/playlist.ts
@@ -54,7 +54,11 @@ export class Playlist {
   /**
    * The videos in the playlist. Only available after calling [[Playlist.fetchVideos]].
    */
-  public videos: Video[]
+  public videos: {
+    results: Video[]
+    prevPageToken: string
+    nextPageToken: string
+  }
 
   /**
    * The ID of the creator of the playlist.
@@ -144,8 +148,8 @@ export class Playlist {
    * Adds videos in this playlist to the `videos` property of this playlist.
    * @param maxResults Fetches all videos if <=0.
    */
-  public async fetchVideos (maxResults: number = 10, parts?: PlaylistItemParts) {
-    this.videos = await this.youtube.getPlaylistItems(this.id, maxResults, parts)
+  public async fetchVideos (maxResults: number = 10, parts?: PlaylistItemParts, pageToken?: string) {
+    this.videos = await this.youtube.getPlaylistItems(this.id, maxResults, parts, pageToken)
     return this.videos
   }
 
@@ -190,9 +194,9 @@ export class Playlist {
     const video = await this.youtube.oauth.addPlaylistItem(this.id, videoId, position, note)
 
     if (this.videos) {
-      this.videos.push(video)
+      this.videos.results.push(video)
     } else {
-      this.videos = [ video ]
+      this.videos = { results: [ video ], prevPageToken: undefined, nextPageToken: undefined }
     }
 
     return video
@@ -232,10 +236,10 @@ export class Playlist {
     await this.youtube.oauth.deletePlaylistItem(playlistItemId)
 
     if (this.videos) {
-      const index = this.videos.findIndex(v => v.data.id === playlistItemId)
+      const index = this.videos.results.findIndex(v => v.data.id === playlistItemId)
 
       if (index) {
-        this.videos.splice(index, 1)
+        this.videos.results.splice(index, 1)
       }
     }
   }

--- a/src/entities/video.ts
+++ b/src/entities/video.ts
@@ -136,7 +136,11 @@ export class Video {
   /**
    * The video's comments. Only defined when [[Video.fetchComments]] is called.
    */
-  public comments: YTComment[]
+  public comments: {
+    results: YTComment[]
+    prevPageToken: string
+    nextPageToken: string
+  }
 
   /**
    * The number of comments on the video.
@@ -265,10 +269,10 @@ export class Video {
   public async postComment (text: string) {
     const comment = await this.youtube.oauth.postComment(text, this.channel.id, this.id)
 
-    if (this.comments !== undefined) {
-      this.comments.push(comment)
+    if (this.comments) {
+      this.comments.results.push(comment)
     } else {
-      this.comments = [ comment ]
+      this.comments = { results: [ comment ], prevPageToken: undefined, nextPageToken: undefined }
     }
 
     return comment
@@ -287,8 +291,8 @@ export class Video {
    * Fetches the video's comments and assigns them to [[Video.comments]].
    * @param maxResults The maximum amount of comments to fetch
    */
-  public async fetchComments (maxResults: number = 10, parts?: CommentThreadParts) {
-    this.comments = await this.youtube.getVideoComments(this.id, maxResults, parts)
+  public async fetchComments (maxResults: number = 10, parts?: CommentThreadParts, pageToken?: string) {
+    this.comments = await this.youtube.getVideoComments(this.id, maxResults, parts, pageToken)
     return this.comments
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,15 +234,16 @@ export class YouTube {
   }
 
   /**
-   * Get `maxResults` videos in a [[Playlist]]. Used mostly internally with [[Playlist.fetchVideos]].
+   * Get `maxResults` [[Video]]s in a [[Playlist]]. Used mostly internally with [[Playlist.fetchVideos]].
    * @param playlistResolvable The URL, ID, or Title of the playlist.
    * @param maxResults The maximum amount of videos to get from the playlist. If <=0, returns all videos in the playlist.
    * @param parts The parts of the videos to fetch (saves quota if you aren't using certain properties!)
    * @returns Partial video objects.
    */
-  public async getPlaylistItems (playlistResolvable: string | Playlist, maxResults: number = 10, parts?: PlaylistItemParts) {
+  public async getPlaylistItems (playlistResolvable: string | Playlist, maxResults: number = 10, parts?: PlaylistItemParts, pages: number = 1, pageToken?: string) {
     const playlistId = await GenericService.getId(this, playlistResolvable, Playlist)
-    return GenericService.getPaginatedItems(this, 'playlistItems', false, playlistId, maxResults, null, parts) as Promise<Video[]>
+    return GenericService.getPaginatedItems(this, 'playlistItems', false, playlistId, maxResults, null, parts, pages, pageToken) as
+      Promise<{ results: Video[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
@@ -252,9 +253,10 @@ export class YouTube {
    * @param parts The parts of the comments to fetch (saves quota if you aren't using certain properties!)
    * @returns Partial comment objects.
    */
-  public async getVideoComments (videoResolvable: string | Video, maxResults: number = 10, parts?: CommentThreadParts) {
+  public async getVideoComments (videoResolvable: string | Video, maxResults: number = 10, parts?: CommentThreadParts, pages: number = 1, pageToken?: string) {
     const videoId = await GenericService.getId(this, videoResolvable, Video)
-    return GenericService.getPaginatedItems(this, 'commentThreads:video', false, videoId, maxResults, null, parts) as Promise<YTComment[]>
+    return GenericService.getPaginatedItems(this, 'commentThreads:video', false, videoId, maxResults, null, parts, pages, pageToken) as
+      Promise<{ results: YTComment[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
@@ -264,9 +266,10 @@ export class YouTube {
    * @param parts The parts of the comments to fetch (saves quota if you aren't using certain properties!)
    * @returns Partial comment objects.
    */
-  public async getChannelComments (channelResolvable: string | Channel, maxResults: number = 10, parts?: CommentThreadParts) {
+  public async getChannelComments (channelResolvable: string | Channel, maxResults: number = 10, parts?: CommentThreadParts, pages: number = 1, pageToken?: string) {
     const channelId = await GenericService.getId(this, channelResolvable, Channel)
-    return GenericService.getPaginatedItems(this, 'commentThreads:channel', false, channelId, maxResults, null, parts) as Promise<YTComment[]>
+    return GenericService.getPaginatedItems(this, 'commentThreads:channel', false, channelId, maxResults, null, parts, pages, pageToken) as
+      Promise<{ results: YTComment[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
@@ -276,9 +279,10 @@ export class YouTube {
    * @param parts The parts of the playlists to fetch (saves quota if you aren't using certain properties!)
    * @returns Partial playlist objects.
    */
-  public async getChannelPlaylists (channelResolvable: string | Channel, maxResults: number = 10, parts?: PlaylistParts) {
+  public async getChannelPlaylists (channelResolvable: string | Channel, maxResults: number = 10, parts?: PlaylistParts, pages: number = 1, pageToken?: string) {
     const channelId = await GenericService.getId(this, channelResolvable, Channel)
-    return GenericService.getPaginatedItems(this, 'playlists:channel', false, channelId, maxResults, null, parts) as Promise<Playlist[]>
+    return GenericService.getPaginatedItems(this, 'playlists:channel', false, channelId, maxResults, null, parts, pages, pageToken) as
+      Promise<{ results: Playlist[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
@@ -288,9 +292,10 @@ export class YouTube {
    * @param parts The parts of the subscriptions to fetch (saves quota if you aren't using certain properties!)
    * @returns Partial subscription objects.
    */
-  public async getChannelSubscriptions (channelResolvable: string | Channel, maxResults: number = 10, parts?: SubscriptionParts) {
+  public async getChannelSubscriptions (channelResolvable: string | Channel, maxResults: number = 10, parts?: SubscriptionParts, pages: number = 1, pageToken?: string) {
     const channelId = await GenericService.getId(this, channelResolvable, Channel)
-    return GenericService.getPaginatedItems(this, 'subscriptions', false, channelId, maxResults, null, parts) as Promise<Subscription[]>
+    return GenericService.getPaginatedItems(this, 'subscriptions', false, channelId, maxResults, null, parts, pages, pageToken) as
+      Promise<{ results: Subscription[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
@@ -300,8 +305,9 @@ export class YouTube {
    * @param parts The parts of the replies to fetch (saves quota if you aren't using certain properties!)
    * @returns Partial comment objects.
    */
-  public getCommentReplies (commentId: string, maxResults: number = 10, parts?: CommentParts) {
-    return GenericService.getPaginatedItems(this, 'comments', false, commentId, maxResults, null, parts) as Promise<YTComment[]>
+  public getCommentReplies (commentId: string, maxResults: number = 10, parts?: CommentParts, pages: number = 1, pageToken?: string) {
+    return GenericService.getPaginatedItems(this, 'comments', false, commentId, maxResults, null, parts, pages, pageToken) as
+      Promise<{ results: YTComment[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
@@ -310,31 +316,32 @@ export class YouTube {
    * @param parts The parts of the channel sections to fetch (saves quota if you aren't using certain properties!)
    * @returns Partial channel section objects.
    */
-  public async getChannelSections (channelResolvable: string | Channel, parts?: ChannelSectionParts) {
+  public async getChannelSections (channelResolvable: string | Channel, parts?: ChannelSectionParts, pages: number = 1, pageToken?: string) {
     const channelId = await GenericService.getId(this, channelResolvable, Channel)
-    return GenericService.getPaginatedItems(this, 'channelSections', false, channelId, null, null, parts) as Promise<ChannelSection[]>
+    return GenericService.getPaginatedItems(this, 'channelSections', false, channelId, null, null, parts, pages, pageToken) as
+      Promise<{ results: ChannelSection[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
    * Get the list of categories in `this.region`.
    * @param all Whether or not to get all categories (otherwise just gets a page).
    */
-  public getCategories (all: boolean = false) {
-    return GenericService.getPaginatedItems(this, 'videoCategories', false, null, all ? -1 : 100) as Promise<VideoCategory[]>
+  public async getCategories (all: boolean = false) {
+    return (await GenericService.getPaginatedItems(this, 'videoCategories', false, null, all ? -1 : 100)).results as VideoCategory[]
   }
 
   /**
    * Get a list of languages that YouTube supports.
    */
-  public getLanguages () {
-    return GenericService.getPaginatedItems(this, 'i18nLanguages', false, null) as Promise<Language[]>
+  public async getLanguages () {
+    return (await GenericService.getPaginatedItems(this, 'i18nLanguages', false, null)).results as Language[]
   }
 
   /**
    * Get a list of regions that YouTube supports.
    */
-  public getRegions () {
-    return GenericService.getPaginatedItems(this, 'i18nRegions', false, null) as Promise<Region[]>
+  public async getRegions () {
+    return (await GenericService.getPaginatedItems(this, 'i18nRegions', false, null)).results as Region[]
   }
 }
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -64,9 +64,10 @@ export class OAuth {
    * @param maxResults The maximum number of subscriptions to fetch.
    * Fetches 10 by default. Set to a value <=0 to fetch all.
    */
-  public getMySubscriptions (maxResults: number = 10, parts?: SubscriptionParts): Promise<Subscription[]> {
+  public getMySubscriptions (maxResults: number = 10, parts?: SubscriptionParts) {
     this.checkTokenAndThrow()
-    return GenericService.getPaginatedItems(this.youtube, 'subscriptions', true, null, maxResults, null, parts) as Promise<Subscription[]>
+    return GenericService.getPaginatedItems(this.youtube, 'subscriptions', true, null, maxResults, null, parts) as
+      Promise<{ results: Subscription[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
@@ -75,9 +76,10 @@ export class OAuth {
    * @param maxResults The maximum number of playlists to fetch.
    * Fetches 10 by default. Set to a value <=0 to fetch all.
    */
-  public getMyPlaylists (maxResults: number = 10, parts?: PlaylistParts): Promise<Playlist[]> {
+  public getMyPlaylists (maxResults: number = 10, parts?: PlaylistParts) {
     this.checkTokenAndThrow()
-    return GenericService.getPaginatedItems(this.youtube, 'playlists:channel', true, null, maxResults, null, parts) as Promise<Playlist[]>
+    return GenericService.getPaginatedItems(this.youtube, 'playlists:channel', true, null, maxResults, null, parts) as
+      Promise<{ results: Playlist[]; prevPageToken: string; nextPageToken: string }>
   }
 
   /**
@@ -147,7 +149,12 @@ export class OAuth {
     if (result.replies) {
       result.replies.comments.forEach(reply => {
         const created = new YTComment(this.youtube, reply, type)
-        comment.replies.push(created)
+
+        if (comment.replies) {
+          comment.replies.results.push(created)
+        } else {
+          comment.replies = { results: [ created ], prevPageToken: undefined, nextPageToken: undefined }
+        }
       })
     }
 
@@ -860,6 +867,7 @@ export class OAuth {
    */
   public getVideoAbuseReportReasons () {
     this.checkTokenAndThrow()
-    return GenericService.getPaginatedItems(this.youtube, 'videoAbuseReportReasons', false) as Promise<VideoAbuseReportReason[]>
+    return GenericService.getPaginatedItems(this.youtube, 'videoAbuseReportReasons', false) as
+      Promise<{ results: VideoAbuseReportReason[]; prevPageToken: string; nextPageToken: string }>
   }
 }

--- a/src/types/GetPaginatedItems.ts
+++ b/src/types/GetPaginatedItems.ts
@@ -9,5 +9,8 @@ export type PaginatedItemsEndpoints = 'playlistItems' | 'playlists' | 'playlists
 /**
  * @ignore
  */
-export type PaginatedItemsReturns = Video[] | YTComment[] | Playlist[] | Subscription[] | VideoCategory[] | VideoAbuseReportReason[] | Language[] |
-  Region[] | ChannelSection[] | Caption[]
+export type PaginatedItemsReturns = {
+  results: Video[] | YTComment[] | Playlist[] | Subscription[] | VideoCategory[] | VideoAbuseReportReason[] | Language[] | Region[] | ChannelSection[] | Caption[]
+  prevPageToken?: string
+  nextPageToken?: string
+ }

--- a/test/playlist-items.spec.ts
+++ b/test/playlist-items.spec.ts
@@ -22,10 +22,10 @@ describe('Playlist items', () => {
   })
 
   it('should return an array with a length of <= maxResults', async () => {
-    expect((await youtube.getPlaylistItems('PLMC9KNkIncKvYin_USF1qoJQnIyMAfRxl', 2, [ 'id' ])).length).to.be.lessThan(3)
+    expect((await youtube.getPlaylistItems('PLMC9KNkIncKvYin_USF1qoJQnIyMAfRxl', 2, [ 'id' ])).results.length).to.be.lessThan(3)
   })
 
   it('should return an array the size of the playlist if maxResults isn\'t defined or is < 1', async () => {
-    expect((await youtube.getPlaylistItems('PLMC9KNkIncKvYin_USF1qoJQnIyMAfRxl', 0, [ 'id' ])).length).to.be.greaterThan(50)
+    expect((await youtube.getPlaylistItems('PLMC9KNkIncKvYin_USF1qoJQnIyMAfRxl', 0, [ 'id' ])).results.length).to.be.greaterThan(50)
   })
 })


### PR DESCRIPTION
- [x] Return prev and next page tokens in paginated responses
- [x] Add starting `pageToken` parameter to paginated methods
- [x] Add `pages` parameter to paginated methods to allow for simple multi-page requests
- [ ] Update entity methods to include this functionality (in progress)
- [ ] Update documentation
- [ ] Add tests for all this (in progress)